### PR TITLE
Widening&narrowing

### DIFF
--- a/Kinder/Classes/Item.cs
+++ b/Kinder/Classes/Item.cs
@@ -50,7 +50,7 @@ namespace Kinder.Classes
         public Item(int ID, DateTime DateOfPurchase, ConditionEnum Condition, CathegoryEnum Cathegory, int UserID, Dimensions size, int KarmaPrice)
         {
             this.ID = ID;
-            this.dateOfPurchase = dateOfPurchase;
+            this.dateOfPurchase = DateOfPurchase;
             this.Condition = Condition;
             this.Cathegory = Cathegory;
             this.UserID = UserID;
@@ -103,12 +103,12 @@ namespace Kinder.Classes
                     dateOfPurchase = value;
             }
         }
-        public string dateStr { get; set; }
+        public string DateStr { get; set; }
 
         public ConditionEnum Condition { get; set; }
         public CathegoryEnum Cathegory { get; set; }
 
-        public int UserID;
+        public int UserID { get; set; }
 
         public Dimensions size;
         public Dimensions Size

--- a/Kinder/Classes/Item.cs
+++ b/Kinder/Classes/Item.cs
@@ -34,7 +34,7 @@ namespace Kinder.Classes
             this.Width = Width;
         }
 
-        public string ToString()
+        public override string ToString()
         {
             return Length.ToString() + ',' + Height.ToString() + ',' + Width.ToString();
         }

--- a/Kinder/Data_files/Items.txt
+++ b/Kinder/Data_files/Items.txt
@@ -26,4 +26,3 @@
 6;2012-01-05;Good;Transport;2;0,0,0;20;name;desc
 5;2020-01-05;Fair;Transport;1;7,5,6;157;name;desc
 4;2020-01-05;Mint;Furniture;0;2,3,1;157;name;desc
-24;2021-01-05;Fair;Education;0;1,2,3;157;Name;A fascinating description...

--- a/Kinder/Data_files/Items.txt
+++ b/Kinder/Data_files/Items.txt
@@ -1,14 +1,14 @@
+36;2002-01-05;Very_good;Furniture;1;6,4,2;100;named;i like trains
 34;2020-01-05;Near_mint;Furniture;1;1,2,3;157;Unnamed item;Undescribed item
 33;2020-01-05;Mint;Transport;1;1,2,3;157;Name;A fascinating description...
 32;1998-09-01;Mint;Furniture;1;7,5,3;157;Name;A fascinating description...
-31;2011-01-05;Fair;Education;1;7,1,4;1000;"Kompiuteriu Architektura";10/10 book
+31;2011-01-05;Fair;Education;1;7,1,4;100;"Kompiuteriu Architektura";10/10 book
 30;2020-01-05;Mint;Furniture;0;1,3,2;157;name;desc
 29;2020-01-05;Mint;Furniture;0;1,3,2;157;name;desc
 28;2020-01-05;Good;Technology;0;5,6,4;157;name;desc
 27;2020-01-05;Good;Technology;0;5,6,4;157;name;desc
 26;2020-01-05;Fair;Education;0;2,3,1;157;name;desc
 25;2020-01-05;Fair;Education;0;4,6,5;157;name;desc
-24;2020-01-05;Fair;Education;0;4,6,5;157;name;desc
 23;2020-01-05;Good;Furniture;0;2,3,1;157;name;desc
 22;2020-01-05;Fair;Education;0;2,3,1;157;name;desc
 21;2020-01-05;Near_mint;Furniture;0;8,9,7;157;name;desc
@@ -17,13 +17,13 @@
 18;2019-11-12;Good;Education;1;7,3,5;12;name;desc
 17;2019-11-12;Good;Education;1;1,2,3;12;name;desc
 16;2020-01-05;Fair;Furniture;1;1,2,3;157;Name;A fascinating description...
-15;2021-10-05;Mint;Education;1;13,10,12;1000;name;desc
+15;2021-10-05;Mint;Education;1;13,10,12;100;name;desc
 12;2020-01-05;Fair;Education;1;1,2,3;12;name;desc
-11;1998-01-05;Near_mint;Technology;3;1,2,3;600;name;desc
+11;1998-01-05;Near_mint;Technology;3;1,2,3;60;name;desc
 10;2021-10-05;Mint;Education;1;12,13,10;100;name;desc
-9;2010-01-05;Mint;Transport;2;0,0,0;330;name;desc
+9;2010-01-05;Mint;Transport;2;0,0,0;33;name;desc
 7;2020-01-05;Fair;Furniture;4;0,0,0;220;name;desc
 6;2012-01-05;Good;Transport;2;0,0,0;20;name;desc
 5;2020-01-05;Fair;Transport;1;7,5,6;157;name;desc
 4;2020-01-05;Mint;Furniture;0;2,3,1;157;name;desc
-36;2002-01-05;Very_good;Furniture;1;6,4,2;100004;named;i like trains
+24;2021-01-05;Fair;Education;0;1,2,3;157;Name;A fascinating description...

--- a/Kinder/ItemsListing.xaml
+++ b/Kinder/ItemsListing.xaml
@@ -26,7 +26,7 @@
                 <DataGridTextColumn Header="id" Binding="{Binding ID}" Width="25"></DataGridTextColumn>
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="100"></DataGridTextColumn>
                 <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*"></DataGridTextColumn>
-                <DataGridTextColumn Header="Date of buying" Binding="{Binding dateStr}" Width="100"></DataGridTextColumn>
+                <DataGridTextColumn Header="Date of buying" Binding="{Binding DateStr}" Width="100"></DataGridTextColumn>
                 <DataGridTextColumn Header="Condition" Binding="{Binding Condition}" Width="100"></DataGridTextColumn>
                 <DataGridTextColumn Header="Category" Binding="{Binding Cathegory}" Width="100"></DataGridTextColumn>
                 <DataGridTextColumn Header="size" Binding="{Binding SizeStr}" Width="50"></DataGridTextColumn>

--- a/Kinder/ItemsListing.xaml.cs
+++ b/Kinder/ItemsListing.xaml.cs
@@ -29,9 +29,10 @@ namespace Kinder
         }
 
         private List<Item> ItemsList = new();
-        private int CurrentUserID = User.CurrentUserID; //TODO: current user session
+        private int CurrentUserID = User.CurrentUserID;
         private string FileLocation = System.IO.Path.Combine(Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName, "Data_files\\Items.txt");
 
+        //reading file
         private void ReadDataFromFile()
         {
             ItemsList.Clear();
@@ -120,8 +121,24 @@ namespace Kinder
 
             NewItem.UserID = CurrentUserID;
 
+            //narrowing convertion:
+            long length_long, width_long, height_long;
+
+            length_long = long.Parse(DimsTextBoxL.Text);
+            width_long = long.Parse(DimsTextBoxW.Text);
+            height_long = long.Parse(DimsTextBoxH.Text);
+
+            int length_int, width_int, height_int;
+
+            checked
+            {
+                length_int = (int)length_long;
+                width_int = (int)width_long;
+                height_int = (int)height_long;
+            }
+
             //named argument:
-            NewItem.Size = new Dimensions(Length: int.Parse(DimsTextBoxL.Text), Height: int.Parse(DimsTextBoxH.Text), Width: int.Parse(DimsTextBoxW.Text));
+            NewItem.Size = new Dimensions(Length: length_int, Height: height_int, Width: width_int);
             NewItem.SizeStr = NewItem.Size.ToString();
             
             //widening convertion:
@@ -216,7 +233,7 @@ namespace Kinder
 
             if (PointsTextBox.Text.Length > 0)
             {
-                classObj.KarmaPrice = int.Parse(PointsTextBox.Text);
+                classObj.KarmaPrice = byte.Parse(PointsTextBox.Text);
             }
 
             if (NameTextBox.Text.Length > 0)

--- a/Kinder/ItemsListing.xaml.cs
+++ b/Kinder/ItemsListing.xaml.cs
@@ -29,7 +29,7 @@ namespace Kinder
         }
 
         private List<Item> ItemsList = new();
-        private int CurrentUserID = 1; //TODO: current user session
+        private int CurrentUserID = User.CurrentUserID; //TODO: current user session
         private string FileLocation = System.IO.Path.Combine(Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName, "Data_files\\Items.txt");
 
         private void ReadDataFromFile()
@@ -67,7 +67,7 @@ namespace Kinder
             result.ID = int.Parse(data[0]);
 
             result.dateOfPurchase = DateTime.Parse(data[1]);
-            result.dateStr = data[1];
+            result.DateStr = data[1];
 
             result.Condition = (ConditionEnum) Enum.Parse(typeof(ConditionEnum), data[2]);
             result.Cathegory = (CathegoryEnum) Enum.Parse(typeof(CathegoryEnum), data[3]);
@@ -108,7 +108,7 @@ namespace Kinder
             NewItem.ID = nextID;
 
             NewItem.DateOfPurchase = DateTime.Parse(DateTextBox.Text);
-            NewItem.dateStr = DateTextBox.Text;
+            NewItem.DateStr = DateTextBox.Text;
 
             String condStr= ConditionComboBox.SelectedItem.ToString();
             Enum.TryParse(condStr, out ConditionEnum condition);
@@ -124,7 +124,12 @@ namespace Kinder
             NewItem.Size = new Dimensions(Length: int.Parse(DimsTextBoxL.Text), Height: int.Parse(DimsTextBoxH.Text), Width: int.Parse(DimsTextBoxW.Text));
             NewItem.SizeStr = NewItem.Size.ToString();
             
-            NewItem.KarmaPrice = int.Parse(PointsTextBox.Text);
+            //widening convertion:
+            NewItem.KarmaPrice = byte.Parse(PointsTextBox.Text);
+
+            /* such convertion allows us to keep points distribution in check. 
+             * Users can't get more that 255 points per item.
+             * with int they could get way way more */
 
             //optional arguments implementation:
             if(NameTextBox.Text.Length > 0)
@@ -173,7 +178,7 @@ namespace Kinder
             if (DateTextBox.Text.Length > 0)
             {
                 classObj.DateOfPurchase = DateTime.Parse(DateTextBox.Text);
-                classObj.dateStr = DateTextBox.Text;
+                classObj.DateStr = DateTextBox.Text;
             }
 
             if(ConditionComboBox.SelectedItem != null)


### PR DESCRIPTION
added widening: 
such convertion allows us to keep points distribution in check: users can't get more that 255 points per item, yet with int they could get way way more.

added narrowing:
just for requirement, it doesn't serve any real purpose.